### PR TITLE
Add Pomodoro user profile sync for bridge matching

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,3 +46,11 @@ model PomodoroSession {
     @@index([authorId, createdAt])
     @@index([todoId])
 }
+
+model PomodoroUserProfile {
+    authorId     String   @id
+    primaryEmail String   @unique
+    displayName  String?
+    createdAt    DateTime @default(now())
+    updatedAt    DateTime @updatedAt
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,7 +49,7 @@ model PomodoroSession {
 
 model PomodoroUserProfile {
     authorId     String   @id
-    primaryEmail String   @unique
+    primaryEmail String   @unique @db.Citext
     displayName  String?
     createdAt    DateTime @default(now())
     updatedAt    DateTime @updatedAt

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,8 +14,8 @@ import WelcomePage from "~/components/WelcomePage";
 import { api } from "~/utils/api";
 
 export default function Home() {
-  const { isLoaded: userLoaded, isSignedIn } = useUser();
-  const hasSyncedViewerProfile = useRef(false);
+  const { isLoaded: userLoaded, isSignedIn, user } = useUser();
+  const lastSyncedViewerProfileForUserId = useRef<string | null>(null);
   const [homeTab, setHomeTab] = useState<"task" | "analytics">("task");
   const [enableTimer, setEnableTimer] = useState(false);
   const [selectedTodo, setSelectedTodo] = useState<{
@@ -103,11 +103,28 @@ export default function Home() {
   }, [selectedTodo.value, fullTodo.done]);
 
   useEffect(() => {
-    if (!userLoaded || !isSignedIn || hasSyncedViewerProfile.current) return;
+    lastSyncedViewerProfileForUserId.current = null;
+  }, [user?.id]);
 
-    hasSyncedViewerProfile.current = true;
-    syncViewerProfile.mutate();
-  }, [isSignedIn, syncViewerProfile, userLoaded]);
+  useEffect(() => {
+    const currentUserId = user?.id ?? null;
+
+    if (!userLoaded || !isSignedIn || !currentUserId) {
+      lastSyncedViewerProfileForUserId.current = null;
+      return;
+    }
+
+    if (lastSyncedViewerProfileForUserId.current === currentUserId) return;
+
+    lastSyncedViewerProfileForUserId.current = currentUserId;
+    syncViewerProfile.mutate(undefined, {
+      onError() {
+        if (lastSyncedViewerProfileForUserId.current === currentUserId) {
+          lastSyncedViewerProfileForUserId.current = null;
+        }
+      },
+    });
+  }, [isSignedIn, syncViewerProfile, user?.id, userLoaded]);
 
   // Persist selected tab across visits
   useEffect(() => {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import { useUser } from "@clerk/nextjs";
 import Head from "next/head";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import AnalyticsDashboard from "~/components/AnalyticsDashboard";
 import EditTodoForm from "~/components/EditTodoForm";
 import Footer from "~/components/Footer";
@@ -15,6 +15,7 @@ import { api } from "~/utils/api";
 
 export default function Home() {
   const { isLoaded: userLoaded, isSignedIn } = useUser();
+  const hasSyncedViewerProfile = useRef(false);
   const [homeTab, setHomeTab] = useState<"task" | "analytics">("task");
   const [enableTimer, setEnableTimer] = useState(false);
   const [selectedTodo, setSelectedTodo] = useState<{
@@ -47,6 +48,7 @@ export default function Home() {
   api.todo.getAll.useQuery(undefined, {
     enabled: userLoaded && !!isSignedIn,
   });
+  const syncViewerProfile = api.todo.syncViewerProfile.useMutation();
 
   const selectedTodoQuery = api.todo.getSelectedTodo.useQuery(
     { todoId: selectedTodo.value },
@@ -99,6 +101,13 @@ export default function Home() {
       setEnableTimer(false);
     }
   }, [selectedTodo.value, fullTodo.done]);
+
+  useEffect(() => {
+    if (!userLoaded || !isSignedIn || hasSyncedViewerProfile.current) return;
+
+    hasSyncedViewerProfile.current = true;
+    syncViewerProfile.mutate();
+  }, [isSignedIn, syncViewerProfile, userLoaded]);
 
   // Persist selected tab across visits
   useEffect(() => {

--- a/src/server/api/routers/todo.ts
+++ b/src/server/api/routers/todo.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { clerkClient } from "@clerk/nextjs/server";
 import type { Todo } from "@prisma/client";
 import { z } from "zod";
 import { createTRPCRouter, privateProcedure } from "~/server/api/trpc";
@@ -52,7 +53,51 @@ const formatPracticeLayer = (layer?: string | null) => {
     .join(" ");
 };
 
+const getPrimaryEmailAddress = async (authorId: string) => {
+  const client = await clerkClient();
+  const user = await client.users.getUser(authorId);
+  const primaryEmail =
+    user.emailAddresses.find(
+      (emailAddress) => emailAddress.id === user.primaryEmailAddressId
+    )?.emailAddress ??
+    user.emailAddresses[0]?.emailAddress ??
+    null;
+
+  const displayName =
+    user.fullName?.trim() ||
+    [user.firstName, user.lastName].filter(Boolean).join(" ").trim() ||
+    user.username?.trim() ||
+    primaryEmail;
+
+  return {
+    primaryEmail: primaryEmail?.trim().toLowerCase() ?? null,
+    displayName: displayName?.trim() || null,
+  };
+};
+
 export const todoRouter = createTRPCRouter({
+  syncViewerProfile: privateProcedure.mutation(async ({ ctx }) => {
+    const profile = await getPrimaryEmailAddress(ctx.userId);
+
+    if (!profile.primaryEmail) {
+      throw new Error("No verified email was found for the signed-in user.");
+    }
+
+    return ctx.prisma.pomodoroUserProfile.upsert({
+      where: {
+        authorId: ctx.userId,
+      },
+      update: {
+        primaryEmail: profile.primaryEmail,
+        displayName: profile.displayName,
+      },
+      create: {
+        authorId: ctx.userId,
+        primaryEmail: profile.primaryEmail,
+        displayName: profile.displayName,
+      },
+    });
+  }),
   getAll: privateProcedure.query(async ({ ctx }) => {
     const todos = await ctx.prisma.todo.findMany({
       where: {
@@ -328,8 +373,9 @@ export const todoRouter = createTRPCRouter({
 
     let currentStreak = 0;
     for (let i = days.length - 1; i >= 0; i--) {
-      if (days[i]?.count && days[i].count > 0) currentStreak += 1;
-      else break;
+      const day = days[i];
+      if (!day || day.count <= 0) break;
+      currentStreak += 1;
     }
 
     const totalActiveDays = days.filter((day) => day.count > 0).length;

--- a/src/server/api/routers/todo.ts
+++ b/src/server/api/routers/todo.ts
@@ -56,11 +56,14 @@ const formatPracticeLayer = (layer?: string | null) => {
 const getPrimaryEmailAddress = async (authorId: string) => {
   const client = await clerkClient();
   const user = await client.users.getUser(authorId);
+  const verifiedEmailAddresses = user.emailAddresses.filter(
+    (emailAddress) => emailAddress.verification.status === "verified"
+  );
   const primaryEmail =
-    user.emailAddresses.find(
+    verifiedEmailAddresses.find(
       (emailAddress) => emailAddress.id === user.primaryEmailAddressId
     )?.emailAddress ??
-    user.emailAddresses[0]?.emailAddress ??
+    verifiedEmailAddresses[0]?.emailAddress ??
     null;
 
   const displayName =


### PR DESCRIPTION
## Summary
- add a `PomodoroUserProfile` model to persist `authorId` to email/display name mappings
- sync the signed-in viewer's Clerk profile into that table from the home page
- use the stored profile data to support email-based account matching from the deliberate-coder bridge

## Testing
- `pnpm exec prisma generate`
- `pnpm lint`
- `pnpm build`

## Notes
- `pnpm exec tsc --noEmit` still reports pre-existing unrelated type errors in config and shared UI files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User profiles are now persisted and automatically synchronized when you sign in, making your profile data available across sessions.
  * Sign-in synchronization is more reliable and will retry on transient errors to ensure your profile stays up to date.

* **Bug Fixes**
  * Streak heatmap calculation refined to correctly handle missing daily entries and zero-activity days.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->