### PR TITLE
Fix Deliberate Coder details in Pomodoro modal

### DIFF
--- a/src/server/api/routers/todo.ts
+++ b/src/server/api/routers/todo.ts
@@ -61,7 +61,7 @@ const normalizeConceptList = (concepts: string[]) => {
 };
 
 const conceptListsMatch = (left: string[], right: string[]) => {
-  if (left.length === 0 || left.length !== right.length) return false;
+  if (left.length !== right.length) return false;
   return left.every((concept, index) => concept === right[index]);
 };
 

--- a/src/server/api/routers/todo.ts
+++ b/src/server/api/routers/todo.ts
@@ -53,6 +53,43 @@ const formatPracticeLayer = (layer?: string | null) => {
     .join(" ");
 };
 
+const cleanDeliberateCoderSummary = ({
+  summary,
+  layerLabel,
+  conceptTags,
+}: {
+  summary?: string | null;
+  layerLabel?: string | null;
+  conceptTags: string[];
+}) => {
+  if (!summary) return null;
+
+  const normalizedLayer = layerLabel?.trim().toLowerCase();
+  const normalizedConcepts = conceptTags.join(", ").trim().toLowerCase();
+  const usefulParts = summary
+    .split(/\s+·\s+/)
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .filter((part) => {
+      const normalizedPart = part.toLowerCase();
+      if (
+        normalizedLayer &&
+        normalizedPart === `layer: ${normalizedLayer}`
+      ) {
+        return false;
+      }
+      if (
+        normalizedConcepts &&
+        normalizedPart === `concepts: ${normalizedConcepts}`
+      ) {
+        return false;
+      }
+      return true;
+    });
+
+  return usefulParts.length > 0 ? usefulParts.join(" · ") : null;
+};
+
 const getPrimaryEmailAddress = async (authorId: string) => {
   const client = await clerkClient();
   const user = await client.users.getUser(authorId);
@@ -494,6 +531,19 @@ export const todoRouter = createTRPCRouter({
             .filter(Boolean)
           : [];
 
+        const layerLabel =
+          source === "deliberate_coder_sync"
+            ? formatPracticeLayer(session.externalLayer)
+            : null;
+        const summary =
+          source === "deliberate_coder_sync"
+            ? cleanDeliberateCoderSummary({
+              summary: session.externalSummary,
+              layerLabel,
+              conceptTags,
+            })
+            : null;
+
         itemMap.set(groupingKey, {
           id: groupingKey,
           todoId: session.todoId,
@@ -511,14 +561,8 @@ export const todoRouter = createTRPCRouter({
             source === "deliberate_coder_sync"
               ? "Deliberate Coder"
               : "Pomodoro Todo",
-          layerLabel:
-            source === "deliberate_coder_sync"
-              ? formatPracticeLayer(session.externalLayer)
-              : null,
-          summary:
-            source === "deliberate_coder_sync"
-              ? session.externalSummary ?? null
-              : null,
+          layerLabel,
+          summary,
           conceptTags,
         });
       }

--- a/src/server/api/routers/todo.ts
+++ b/src/server/api/routers/todo.ts
@@ -53,6 +53,18 @@ const formatPracticeLayer = (layer?: string | null) => {
     .join(" ");
 };
 
+const normalizeConceptList = (concepts: string[]) => {
+  return concepts
+    .map((concept) => concept.trim().toLowerCase())
+    .filter(Boolean)
+    .sort();
+};
+
+const conceptListsMatch = (left: string[], right: string[]) => {
+  if (left.length === 0 || left.length !== right.length) return false;
+  return left.every((concept, index) => concept === right[index]);
+};
+
 const cleanDeliberateCoderSummary = ({
   summary,
   layerLabel,
@@ -65,7 +77,7 @@ const cleanDeliberateCoderSummary = ({
   if (!summary) return null;
 
   const normalizedLayer = layerLabel?.trim().toLowerCase();
-  const normalizedConcepts = conceptTags.join(", ").trim().toLowerCase();
+  const normalizedConceptsList = normalizeConceptList(conceptTags);
   const usefulParts = summary
     .split(/\s+·\s+/)
     .map((part) => part.trim())
@@ -78,11 +90,13 @@ const cleanDeliberateCoderSummary = ({
       ) {
         return false;
       }
-      if (
-        normalizedConcepts &&
-        normalizedPart === `concepts: ${normalizedConcepts}`
-      ) {
-        return false;
+      if (normalizedPart.startsWith("concepts:")) {
+        const partConcepts = normalizeConceptList(
+          part.slice(part.indexOf(":") + 1).split(",")
+        );
+        if (conceptListsMatch(partConcepts, normalizedConceptsList)) {
+          return false;
+        }
       }
       return true;
     });


### PR DESCRIPTION
## Summary
- Wraps long mirrored Deliberate Coder session labels inside the Daily Pomodoro Details dialog.
- Prevents summaries, concept tags, and the compatibility info banner from overflowing horizontally.
- Removes duplicated mirrored metadata so layer appears as a badge and concepts appear only once.

## Verification
- `pnpm lint`
- `pnpm build`

Note: `pnpm build` still emits the existing dependency warning about `useContext` from Next/Clerk/React, but completes successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Cleaner streak summaries: redundant layer and concept tags are removed from session summaries; fully filtered or missing summaries now appear blank. For non-Deliberate Coder syncs, layer and summary values remain hidden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->